### PR TITLE
Added indications to rename the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,20 +9,25 @@
 
 #### Scripts included
 
-##### **Init**
+##### Rename project
+[EN] After cloning the project, to rename the project it is necessary to change all the places tha contains the actual project name. For that, usually the IDEs provide ways to perform the refactor.
+
+For PyCharm users follow the steps indicated on the [documentation](https://www.jetbrains.com/help/pycharm/renaming-projects.html). HINT: For experience, apparently, it is better to rename the project name and then the directory name.
+
+Finally, to rename the auto-documentation, it is necessary to modify the file docs>source>index.rst. In the line 6 change *python-boilerplate* for the *new-project-name*.
+
+##### Init
 ```bash
 $ make init
 ```
-Initialize application creating respective virtualenv and installing all 
-dependencies form requirement txt. 
+Initialize application creating respective virtualenv and installing all dependencies form requirement txt. 
 
 ##### Update dependencies
 ```bash
 $ make update-deps
 ```
 
-Update dependencies in requirements.txt file
-to future installs.
+Update dependencies in requirements.txt file to future installs.
 
 ##### Running Test
 ```bash
@@ -37,7 +42,7 @@ Run all application tests
 $ make documentation
 ```
 
-Generate updated  documentation and open it on MAC
+Generate updated documentation and open it on MAC
 
 ##### Run test generating coverage report
 
@@ -48,10 +53,7 @@ $ make coverage
 Run tests and generate coverage report
 
 ### env variables
-This boilerplate comes with [python-dotenv](https://pypi.org/project/python-dotenv/) 
-as a dependency, env variables are declared and loaded from `settings.py` file,
-if you want to add new env vars just create a .env file on on the
-project root directory. 
+This boilerplate comes with [python-dotenv](https://pypi.org/project/python-dotenv/) as a dependency, env variables are declared and loaded from `settings.py` file, if you want to add new env vars just create a .env file on on the project root directory.
 
 
 

--- a/scripts/docs.sh
+++ b/scripts/docs.sh
@@ -3,6 +3,7 @@
 source ./venv/bin/activate && \
   cd docs && \
   sphinx-apidoc -f -o source ../src && \
-  make html clean && \
+  make clean && \
+  make html && \
   sphinx-build -b html source build && \
   open ./build/index.html


### PR DESCRIPTION
In the file docs.sh the command `make html clean` was replaced for this two `make clean && make html`.

This change is proposed for clarity and based on the sphinx documentation.